### PR TITLE
fix: update regex pattern for locales in createContext function

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -91,7 +91,7 @@ export function createContext(options: Options = {}, root = process.cwd!()) {
     // Parse to json and do a simple filter for keyColumn, skipping rows without a defined key.
     let emptyKeySkipped = 0
     const parsed = Papa.parse<any>(csvString, { skipEmptyLines: true, header: true, delimiter: resolvedOptions.delimiter })
-    const locales = parsed.meta.fields!.filter(prop => prop.match(/^\w{2}(?:-\w{2})?$/))
+    const locales = parsed.meta.fields!.filter(prop => prop.match(/^\w{2}(?:-\w{4})?$/))
     let parsedData = parsed.data.filter((row) => {
       if (!isEmptyCell(row[resolvedOptions.keyColumn]))
         return true


### PR DESCRIPTION
Changes Made:

The regular expression used to filter the locales array has been modified as follows:

Original code: const locales = parsed.meta.fields!.filter(prop => prop.match(/^\w{2}(?:-\w{2})?$/))
Updated code: const locales = parsed.meta.fields!.filter(prop => prop.match(/^\w{2}(?:-\w{4})?$/))

Reason for Change:

The regular expression was updated to support language codes like zh-hans and zh-hant. The previous pattern only handled two-character segments, which failed to match such codes correctly.