### PR TITLE
mergeInput option (default:true) to keep input splitted in outDir by …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - File-to-file convert: `en.csv -> en.json`
 - File-to-multiple convert: `i18n.csv -> en.json, vi.json, fr.json,...`
 - Output merging: `i18n_a.csv + i18n_b.csv -> en.json`
+- Input merging: `src1/i18n.csv + src2/i18n.csv -> outDir/src1/en.json, outDir/src2/en.json`
 - File generation: `i18n_files.csv -> cloud_en.json, cloud_fr.json, template_en.html, template_fr.html`
 - And more!
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -22,6 +22,7 @@ export const defaultOptions = {
   localesMatcher: /^\w{2}(?:-\w{2,4})?$/,
   comments: '//',
   mergeOutput: true,
+  mergeInput: true,
   replacePunctuationSpace: true,
   jsonProcessorClean: true,
   fileProcessorClean: true,
@@ -65,6 +66,7 @@ export function createContext(options: Options = {}, root = process.cwd!()) {
     logger.info(`[sheetI18n] Processing: ${relativePath}`)
 
     const pathParsed = path.parse(file)
+    const resolvedOutDirFinal = resolvedOutDir && !resolvedOptions.mergeInput ? path.join(resolvedOutDir, path.basename(pathParsed.dir)) : resolvedOutDir
 
     if (!allowedExtensions.includes(pathParsed.ext))
       return logger.error(`[sheetI18n] unexpected extension: ${file}${spreadsheetExtensions.includes(pathParsed.ext) ? `, xlsx is not enabled.` : ''}`)
@@ -123,14 +125,14 @@ export function createContext(options: Options = {}, root = process.cwd!()) {
 
     const outputs: Record<string, ReturnType<typeof transformToI18n>> = {}
     if (resolvedOptions.valueColumn) {
-      outputs[`${path.resolve(resolvedOutDir || pathParsed.dir, pathParsed.name)}.json`] = transformToI18n(parsedData, resolvedOptions.keyColumn, resolvedOptions.valueColumn, resolvedOptions.keyStyle, resolvedOptions)
+      outputs[`${path.resolve(resolvedOutDirFinal || pathParsed.dir, pathParsed.name)}.json`] = transformToI18n(parsedData, resolvedOptions.keyColumn, resolvedOptions.valueColumn, resolvedOptions.keyStyle, resolvedOptions)
     }
     else {
       if (!locales?.length)
         return logger.error('[sheetI18n] cannot detect any locales column, maybe you need to use valueColumn?')
 
       locales.forEach((locale) => {
-        outputs[`${path.resolve(resolvedOutDir || pathParsed.dir, locale)}.json`] = transformToI18n(parsedData, resolvedOptions.keyColumn, locale, resolvedOptions.keyStyle, resolvedOptions)
+        outputs[`${path.resolve(resolvedOutDirFinal || pathParsed.dir, locale)}.json`] = transformToI18n(parsedData, resolvedOptions.keyColumn, locale, resolvedOptions.keyStyle, resolvedOptions)
       })
     }
 
@@ -199,9 +201,10 @@ export function createContext(options: Options = {}, root = process.cwd!()) {
       })
     })
 
+    const resolvedOutDirFinal = resolvedOutDir && !resolvedOptions.mergeInput ? path.join(resolvedOutDir, path.basename(pathParsed.dir)) : resolvedOutDir
     if (Object.keys(jsons).length) {
       Object.keys(jsons).forEach((k) => {
-        outputFileSync(`${path.resolve(resolvedOutDir || pathParsed.dir, k)}.json`, JSON.stringify(Object.values(jsons[k]), undefined, 2))
+        outputFileSync(`${path.resolve(resolvedOutDirFinal || pathParsed.dir, k)}.json`, JSON.stringify(Object.values(jsons[k]), undefined, 2))
       })
       logger.info(`[sheetI18n] ${relativePath}: Special $JSON keys processed`)
     }
@@ -243,9 +246,10 @@ export function createContext(options: Options = {}, root = process.cwd!()) {
       })
     })
 
+    const resolvedOutDirFinal = resolvedOutDir && !resolvedOptions.mergeInput ? path.join(resolvedOutDir, path.basename(pathParsed.dir)) : resolvedOutDir
     if (Object.keys(files).length) {
       Object.keys(files).forEach((k) => {
-        outputFileSync(`${path.resolve(resolvedOutDir || pathParsed.dir, k)}`, files[k])
+        outputFileSync(`${path.resolve(resolvedOutDirFinal || pathParsed.dir, k)}`, files[k])
       })
       logger.info(`[sheetI18n] ${relativePath}: Special $FILE keys processed`)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,13 @@ export interface Options {
   mergeOutput?: boolean
 
   /**
+   * Merge files inputs or keep input path splitted if outDir specified
+   *
+   * @default true
+   */
+  mergeInput?: boolean
+
+  /**
    * Replaces all spaces followed by a "high" punctuation with a non-breaking space, this is useful to fix ugly UI wrapping for cases like French that requires a space before the punctuations.
    *
    * Punctuations currently scan for is: !$%:;?+-


### PR DESCRIPTION
let's say i have: 
```
src/app1/i18n.csv
src/app2/i18n.csv
```

and want in outDir:
```
dist/app1/i18n.csv
dist/app2/i18n.csv
```

now possible with option: 
```
createContext({
  outDir: 'dist',
  mergeInput: false,
}).scanConvert()
```

